### PR TITLE
Adjust formatting macro usage for compatibility with future Rust compiler versions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -622,7 +622,7 @@ async fn show_files_handler(
             </body>
         </html>",
         file_rows,
-        if path.is_empty() { "" } else { &format!("/{path}") }
+        if path.is_empty() { String::new() } else { format!("/{path}") }
     );
 
     Ok(Html(html))


### PR DESCRIPTION
Hi! This project turned up when assessing the impact of an upcoming Rust compiler bugfix, rust-lang/rust#145838. Currently, formatting macros can cause borrowed temporaries within block tail expressions within their arguments to live longer than they normally would in Rust 2024[^1]. Unfortunately, fixing that inconsistency is a breaking change and this project no longer compiles as-is after the fix. This PR implements a minimal change to address the future error.

For reference, here's the build failure log: https://crater-reports.s3.amazonaws.com/pr-145838/try%23b83b707f97d809763b7861afa7638871f3339a33/gh/musicodeXQQ.updownserv/log.txt

[^1]: See https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html for further details on the expected temporary scope of block tail expressions.